### PR TITLE
Switched to Godot 4 support, Repaired broken RS256 implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Godot Engine GDScript JWT  
 JSON Web Token library for Godot Engine written in GDScript 
 
-## Create JWT
+## Create HS256 JWT
 ```gdscript
 var secret: String = JWTAlgorithmBuilder.random_secret(5)
 var jwt_algorithm: JWTAlgorithm = JWTAlgorithmBuilder.HS256(secret)
@@ -10,6 +10,52 @@ var jwt_builder: JWTBuilder = JWT.create() \
 .with_issuer("Godot") \
 .with_claim("id","someid")
 var jwt: String = jwt_builder.sign(jwt_algorithm)
+```
+
+## Verify HS256 JWT
+```gdscript
+var jwt: String = "<a jwt>"
+var secret: String = "<your secret token>"
+var jwt_algorithm: JWTAlgorithm = JWTAlgorithmBuilder.HS256(secret)
+var jwt_verifier: JWTVerifier = JWT.require(jwt_algorithm) \
+    .with_claim("my-claim","my-value") \
+    .build() # Reusable Verifier
+if jwt_verifier.verify(jwt) == JWTVerifier.JWTExceptions.OK :
+	print("Verified!")
+else:
+	print(jwt_verifier.exception)
+```
+
+## Create RS256 JWT
+```gdscript
+var private_key : CryptoKey = crypto.generate_rsa(4096)
+var public_key : CryptoKey = CryptoKey.new()
+public_key.load_from_string(private_key.save_to_string(true))
+
+var jwt_algorithm: JWTAlgorithm = JWTAlgorithmBuilder.RS256(public_key, private_key)
+var jwt_builder: JWTBuilder = JWT.create() \
+    .with_expires_at(OS.get_unix_time()) \
+    .with_issuer("Godot") \
+    .with_claim("id","someid")
+var jwt: String = jwt_builder.sign(jwt_algorithm)
+```
+
+## Verify RS256 JWT
+```gdscript
+var private_key: CryptoKey = CryptoKey.new()
+var public_key: CryptoKey = CryptoKey.new()
+private_key.load_from_string("<your private key PEM string>", false)
+public_key.load_from_string("<your public key PEM string>", true)
+
+var jwt: String = "<a jwt>"
+var jwt_algorithm: JWTAlgorithm = JWTAlgorithmBuilder.RS256(public_key)
+var jwt_verifier: JWTVerifier = JWT.require(jwt_algorithm) \
+    .with_claim("id","someid") \
+    .build() # Reusable Verifier
+if jwt_verifier.verify(jwt) == JWTVerifier.JWTExceptions.OK :
+	print("Verified!")
+else:
+	print(jwt_verifier.exception)
 ```
 
 ## Decode JWT
@@ -22,24 +68,10 @@ print("%s.%s.%s" % jwt_decoder.parts)
 print(JWTUtils.base64URL_decode(jwt_decoder.get_payload()))
 ```
 
-## Verify JWT
-```gdscript
-var jwt: String = "<a jwt>"
-var secret: String = "<your secret token>"
-var jwt_algorithm: JWTAlgorithm = JWTAlgorithmBuilder.HS256(secret)
-var jwt_verifier: JWTVerifier = JWT.require(jwt_algorithm) \
-.with_claim("my-claim","my-value") \
-.build() # Reusable Verifier
-if jwt_verifier.verify(jwt) == JWTVerifier.Exceptions.OK :
-	print("Verified!")
-else:
-	print(jwt_verifier.exception)
-```
-
 ### JWT Utils
 ```gdscript
-JWTUtils.base64URL_encode(bytes: PoolByteArray) -> String
-JWTUtils.base64URL_decode(string: String) -> String
+JWTUtils.base64URL_encode(bytes: PackedByteArray) -> String
+JWTUtils.base64URL_decode(string: String) -> PackedByteArray
 ```
 
 #### Supported Algorithms

--- a/addons/jwt/plugin.cfg
+++ b/addons/jwt/plugin.cfg
@@ -3,5 +3,5 @@
 name="JWT"
 description=""
 author="Nicolò (fenix-hub) Santilio"
-version="1.5"
+version="1.0"
 script="plugin.gd"

--- a/addons/jwt/plugin.gd
+++ b/addons/jwt/plugin.gd
@@ -1,10 +1,10 @@
-tool
+@tool
 extends EditorPlugin
 
 
 func _enter_tree():
-    pass
+	pass
 
 
 func _exit_tree():
-    pass
+	pass

--- a/addons/jwt/plugin.gd
+++ b/addons/jwt/plugin.gd
@@ -3,8 +3,8 @@ extends EditorPlugin
 
 
 func _enter_tree():
-	pass
+    pass
 
 
 func _exit_tree():
-	pass
+    pass

--- a/addons/jwt/src/JWT.gd
+++ b/addons/jwt/src/JWT.gd
@@ -2,10 +2,10 @@ extends RefCounted
 class_name JWT
 
 static func create(algorithm: JWTAlgorithm = null, header_claims: Dictionary = {}, payload_claims: Dictionary = {}) -> JWTBuilder:
-	return JWTBuilder.new(algorithm, header_claims, payload_claims)
+    return JWTBuilder.new(algorithm, header_claims, payload_claims)
 
 static func decode(jwt: String) -> JWTDecoder:
-	return JWTDecoder.new(jwt)
+    return JWTDecoder.new(jwt)
 
 static func require(algorithm: JWTAlgorithm) -> JWTVerifierBuilder:
-	return JWTVerifierBuilder.new(algorithm)
+    return JWTVerifierBuilder.new(algorithm)

--- a/addons/jwt/src/JWT.gd
+++ b/addons/jwt/src/JWT.gd
@@ -1,11 +1,11 @@
-extends Reference
+extends RefCounted
 class_name JWT
 
 static func create(algorithm: JWTAlgorithm = null, header_claims: Dictionary = {}, payload_claims: Dictionary = {}) -> JWTBuilder:
-    return JWTBuilder.new(algorithm, header_claims, payload_claims)
+	return JWTBuilder.new(algorithm, header_claims, payload_claims)
 
 static func decode(jwt: String) -> JWTDecoder:
-    return JWTDecoder.new(jwt)
+	return JWTDecoder.new(jwt)
 
 static func require(algorithm: JWTAlgorithm) -> JWTVerifierBuilder:
-    return JWTVerifierBuilder.new(algorithm)
+	return JWTVerifierBuilder.new(algorithm)

--- a/addons/jwt/src/JWTAlgorithm.gd
+++ b/addons/jwt/src/JWTAlgorithm.gd
@@ -1,13 +1,13 @@
-extends Reference
+extends RefCounted
 class_name JWTAlgorithm
 
 enum Type {
-    HMAC1,
-    HMAC256,
-    RSA256
+	HMAC1,
+	HMAC256,
+	RSA256
 }
 
-var _hash: int = -1
+var _alg: int = -1
 var _secret: String = ""
 
 var crypto: Crypto = Crypto.new()
@@ -15,30 +15,47 @@ var _public_crypto: CryptoKey = CryptoKey.new()
 var _private_crypto: CryptoKey = CryptoKey.new()
 
 func get_name() -> String:
-    match _hash:
-        Type.HMAC1: return "HSA1"
-        Type.HMAC256: return "HSA256"
-        Type.RSA256: return "RSA256"
-        _: return ""
+	match _alg:
+		# Note: HS1 is not secure and should be removed.
+		Type.HMAC1: return "HSA1"
+		Type.HMAC256: return "HS256"
+		Type.RSA256: return "RS256"
+		_: return ""
 
-func sign(text: String) -> PoolByteArray:
-    var signature_bytes: PoolByteArray = []
-    match self._hash:
-        Type.HMAC1:
-            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8(), text.to_utf8())
-        Type.HMAC256:
-            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8(), text.to_utf8())
-        Type.RSA256:
-            signature_bytes = self.crypto.encrypt(self._private_crypto, text.to_utf8())
-    return signature_bytes
 
+func _digest(ctx_type: HashingContext.HashType, data: PackedByteArray) -> PackedByteArray:
+	var ctx = HashingContext.new()
+	# Start a SHA-256 context.
+	ctx.start(ctx_type)
+	# Check that file exists.
+	ctx.update(data)
+	# Get the computed hash.
+	return ctx.finish()
+
+
+func sign(text: String) -> PackedByteArray:
+	var signature_bytes: PackedByteArray = []
+	match self._alg:
+		Type.HMAC1:
+			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
+		Type.HMAC256:
+			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
+		Type.RSA256:
+			signature_bytes = self.crypto.sign(HashingContext.HASH_SHA256, text.sha256_buffer(), self._private_crypto)
+	return signature_bytes
+
+
+# TODO: Debug this.
 func verify(jwt: JWTDecoder) -> bool:
-    var signature_bytes: PoolByteArray = []
-    match self._hash:
-        Type.HMAC1:
-            signature_bytes = crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8())
-        Type.HMAC256:
-            signature_bytes = crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8())
-        Type.RSA256:
-            signature_bytes = self.crypto.decrypt(self._public_crypto, (jwt.parts[0]+"."+jwt.parts[1]).to_utf8())
-    return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)
+	var signature_bytes: PackedByteArray = []
+	match self._alg:
+		Type.HMAC1:
+			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
+		Type.HMAC256:
+			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
+		Type.RSA256:
+			# type, hash, sig, key
+			print()
+			return self.crypto.verify(HashingContext.HASH_SHA256, (jwt.parts[0]+"."+jwt.parts[1]).sha256_buffer(), JWTUtils.base64URL_decode(jwt.parts[2]), self._public_crypto)
+			#signature_bytes = self.crypto.verify(self._public_crypto, .to_utf8_buffer())
+	return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)

--- a/addons/jwt/src/JWTAlgorithm.gd
+++ b/addons/jwt/src/JWTAlgorithm.gd
@@ -2,9 +2,9 @@ extends RefCounted
 class_name JWTAlgorithm
 
 enum Type {
-	HMAC1,
-	HMAC256,
-	RSA256
+    HMAC1,
+    HMAC256,
+    RSA256
 }
 
 var _alg: int = -1
@@ -15,47 +15,47 @@ var _public_crypto: CryptoKey = CryptoKey.new()
 var _private_crypto: CryptoKey = CryptoKey.new()
 
 func get_name() -> String:
-	match _alg:
-		# Note: HS1 is not secure and should be removed.
-		Type.HMAC1: return "HSA1"
-		Type.HMAC256: return "HS256"
-		Type.RSA256: return "RS256"
-		_: return ""
+    match _alg:
+        # Note: HS1 is not secure and should be removed.
+        Type.HMAC1: return "HSA1"
+        Type.HMAC256: return "HS256"
+        Type.RSA256: return "RS256"
+        _: return ""
 
 
 func _digest(ctx_type: HashingContext.HashType, data: PackedByteArray) -> PackedByteArray:
-	var ctx = HashingContext.new()
-	# Start a SHA-256 context.
-	ctx.start(ctx_type)
-	# Check that file exists.
-	ctx.update(data)
-	# Get the computed hash.
-	return ctx.finish()
+    var ctx = HashingContext.new()
+    # Start a SHA-256 context.
+    ctx.start(ctx_type)
+    # Check that file exists.
+    ctx.update(data)
+    # Get the computed hash.
+    return ctx.finish()
 
 
 func sign(text: String) -> PackedByteArray:
-	var signature_bytes: PackedByteArray = []
-	match self._alg:
-		Type.HMAC1:
-			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
-		Type.HMAC256:
-			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
-		Type.RSA256:
-			signature_bytes = self.crypto.sign(HashingContext.HASH_SHA256, text.sha256_buffer(), self._private_crypto)
-	return signature_bytes
+    var signature_bytes: PackedByteArray = []
+    match self._alg:
+        Type.HMAC1:
+            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
+        Type.HMAC256:
+            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), text.to_utf8_buffer())
+        Type.RSA256:
+            signature_bytes = self.crypto.sign(HashingContext.HASH_SHA256, text.sha256_buffer(), self._private_crypto)
+    return signature_bytes
 
 
 # TODO: Debug this.
 func verify(jwt: JWTDecoder) -> bool:
-	var signature_bytes: PackedByteArray = []
-	match self._alg:
-		Type.HMAC1:
-			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
-		Type.HMAC256:
-			signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
-		Type.RSA256:
-			# type, hash, sig, key
-			print()
-			return self.crypto.verify(HashingContext.HASH_SHA256, (jwt.parts[0]+"."+jwt.parts[1]).sha256_buffer(), JWTUtils.base64URL_decode(jwt.parts[2]), self._public_crypto)
-			#signature_bytes = self.crypto.verify(self._public_crypto, .to_utf8_buffer())
-	return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)
+    var signature_bytes: PackedByteArray = []
+    match self._alg:
+        Type.HMAC1:
+            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
+        Type.HMAC256:
+            signature_bytes = self.crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret.to_utf8_buffer(), (jwt.parts[0]+"."+jwt.parts[1]).to_utf8_buffer())
+        Type.RSA256:
+            # type, hash, sig, key
+            print()
+            return self.crypto.verify(HashingContext.HASH_SHA256, (jwt.parts[0]+"."+jwt.parts[1]).sha256_buffer(), JWTUtils.base64URL_decode(jwt.parts[2]), self._public_crypto)
+            #signature_bytes = self.crypto.verify(self._public_crypto, .to_utf8_buffer())
+    return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)

--- a/addons/jwt/src/JWTAlgorithmBuilder.gd
+++ b/addons/jwt/src/JWTAlgorithmBuilder.gd
@@ -3,7 +3,7 @@ class_name JWTAlgorithmBuilder
 
 
 static func random_secret(length: int = 10) -> String:
-	return Crypto.new().generate_random_bytes(10).get_string_from_utf8()
+	return Crypto.new().generate_random_bytes(length).get_string_from_utf8()
 
 
 static func HSA1(secret: String) -> JWTAlgorithm:

--- a/addons/jwt/src/JWTAlgorithmBuilder.gd
+++ b/addons/jwt/src/JWTAlgorithmBuilder.gd
@@ -3,46 +3,46 @@ class_name JWTAlgorithmBuilder
 
 
 static func random_secret(length: int = 10) -> String:
-	return Crypto.new().generate_random_bytes(length).get_string_from_utf8()
+    return Crypto.new().generate_random_bytes(length).get_string_from_utf8()
 
 
 static func HSA1(secret: String) -> JWTAlgorithm:
-	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-	algorithm._secret = secret
-	algorithm._alg = JWTAlgorithm.Type.HMAC1
-	return algorithm
+    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+    algorithm._secret = secret
+    algorithm._alg = JWTAlgorithm.Type.HMAC1
+    return algorithm
 
 
 static func HS1(secret: String) -> JWTAlgorithm:
-	return HSA1(secret)
+    return HSA1(secret)
 
 
 static func HSA256(secret: String) -> JWTAlgorithm:
-	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-	algorithm._secret = secret
-	algorithm._alg = JWTAlgorithm.Type.HMAC256
-	return algorithm
+    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+    algorithm._secret = secret
+    algorithm._alg = JWTAlgorithm.Type.HMAC256
+    return algorithm
 
 
 static func HS256(secret: String) -> JWTAlgorithm:
-	return HSA256(secret)
+    return HSA256(secret)
 
 
 static func RSA256(public_key: CryptoKey, private_key: CryptoKey = CryptoKey.new()) -> JWTAlgorithm:
-	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-	algorithm._public_crypto = public_key
-	algorithm._private_crypto = private_key
-	algorithm._alg = JWTAlgorithm.Type.RSA256
-	return algorithm
+    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+    algorithm._public_crypto = public_key
+    algorithm._private_crypto = private_key
+    algorithm._alg = JWTAlgorithm.Type.RSA256
+    return algorithm
 
 
 static func RS256(public_key: CryptoKey, private_key: CryptoKey) -> JWTAlgorithm:
-	return RSA256(public_key, private_key)
+    return RSA256(public_key, private_key)
 
 
 static func sign(text: String, algorithm: JWTAlgorithm) -> PackedByteArray:
-	return algorithm.sign(text)
+    return algorithm.sign(text)
 
 
 static func verify(jwt: JWTDecoder, algorithm: JWTAlgorithm) -> bool:
-	return algorithm.verify(jwt)
+    return algorithm.verify(jwt)

--- a/addons/jwt/src/JWTAlgorithmBuilder.gd
+++ b/addons/jwt/src/JWTAlgorithmBuilder.gd
@@ -1,29 +1,48 @@
-extends Reference
+extends RefCounted
 class_name JWTAlgorithmBuilder
 
+
 static func random_secret(length: int = 10) -> String:
-    return Crypto.new().generate_random_bytes(10).get_string_from_utf8()
+	return Crypto.new().generate_random_bytes(10).get_string_from_utf8()
+
 
 static func HSA1(secret: String) -> JWTAlgorithm:
-    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-    algorithm._secret = secret
-    algorithm._hash = JWTAlgorithm.Type.HMAC1
-    return algorithm
+	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+	algorithm._secret = secret
+	algorithm._alg = JWTAlgorithm.Type.HMAC1
+	return algorithm
+
+
+static func HS1(secret: String) -> JWTAlgorithm:
+	return HSA1(secret)
+
 
 static func HSA256(secret: String) -> JWTAlgorithm:
-    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-    algorithm._secret = secret
-    algorithm._hash = JWTAlgorithm.Type.HMAC256
-    return algorithm
+	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+	algorithm._secret = secret
+	algorithm._alg = JWTAlgorithm.Type.HMAC256
+	return algorithm
 
-static func RSA256(public_key: CryptoKey, private_key: CryptoKey) -> JWTAlgorithm:
-    var algorithm: JWTAlgorithm = JWTAlgorithm.new()
-    algorithm._public_crypto = public_key
-    algorithm._private_crypto = private_key
-    return algorithm
 
-static func sign(text: String, algorithm: JWTAlgorithm) -> PoolByteArray:
-    return algorithm.sign(text)
+static func HS256(secret: String) -> JWTAlgorithm:
+	return HSA256(secret)
+
+
+static func RSA256(public_key: CryptoKey, private_key: CryptoKey = CryptoKey.new()) -> JWTAlgorithm:
+	var algorithm: JWTAlgorithm = JWTAlgorithm.new()
+	algorithm._public_crypto = public_key
+	algorithm._private_crypto = private_key
+	algorithm._alg = JWTAlgorithm.Type.RSA256
+	return algorithm
+
+
+static func RS256(public_key: CryptoKey, private_key: CryptoKey) -> JWTAlgorithm:
+	return RSA256(public_key, private_key)
+
+
+static func sign(text: String, algorithm: JWTAlgorithm) -> PackedByteArray:
+	return algorithm.sign(text)
+
 
 static func verify(jwt: JWTDecoder, algorithm: JWTAlgorithm) -> bool:
-    return algorithm.verify(jwt)
+	return algorithm.verify(jwt)

--- a/addons/jwt/src/JWTBaseBuilder.gd
+++ b/addons/jwt/src/JWTBaseBuilder.gd
@@ -2,60 +2,60 @@ extends RefCounted
 class_name JWTBaseBuilder
 
 func with_header(header_claims: Dictionary) -> JWTBaseBuilder:
-	self.header_claims = header_claims
-	return self
+    self.header_claims = header_claims
+    return self
 
 func with_algorithm(algorithm: String) -> JWTBaseBuilder:
-	self.header_claims[JWTClaims.Public.ALGORITHM] = algorithm
-	return self
+    self.header_claims[JWTClaims.Public.ALGORITHM] = algorithm
+    return self
 
 func with_type(type: String) -> JWTBaseBuilder:
-	self.header_claims[JWTClaims.Public.TYPE] = type
-	return self
+    self.header_claims[JWTClaims.Public.TYPE] = type
+    return self
 
 func with_key_id(key_id: String) -> JWTBaseBuilder:
-	self.header_claims[JWTClaims.Public.KEY_ID] = key_id
-	return self
+    self.header_claims[JWTClaims.Public.KEY_ID] = key_id
+    return self
 
 func with_issuer(issuer: String) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.ISSUER, issuer)
-	return self
+    add_claim(JWTClaims.Public.ISSUER, issuer)
+    return self
 
 func with_subject(subject: String) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.SUBJECT, subject)
-	return self
+    add_claim(JWTClaims.Public.SUBJECT, subject)
+    return self
 
 func with_audience(audience: PackedStringArray) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.AUDIENCE, audience)
-	return self
+    add_claim(JWTClaims.Public.AUDIENCE, audience)
+    return self
 
 # Expires At in UNIX time (OS.get_unix_time())
 func with_expires_at(expires_at: int) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.EXPRIES_AT, expires_at)
-	return self
+    add_claim(JWTClaims.Public.EXPRIES_AT, expires_at)
+    return self
 
 # Not Before in UNIX time (OS.get_unix_time())
 func with_not_before(not_before: int) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.NOT_BEFORE, not_before)
-	return self
+    add_claim(JWTClaims.Public.NOT_BEFORE, not_before)
+    return self
 
 # Issued At in UNIX time (OS.get_unix_time())
 func with_issued_at(issued_at: int) -> JWTBaseBuilder:
-	add_claim(JWTClaims.Public.ISSUED_AT, issued_at)
-	return self
+    add_claim(JWTClaims.Public.ISSUED_AT, issued_at)
+    return self
 
 func with_jwt_id(jwt_id: String) -> JWTBaseBuilder:
-	self.header_claims[JWTClaims.Public.JWT_ID] = jwt_id
-	return self
+    self.header_claims[JWTClaims.Public.JWT_ID] = jwt_id
+    return self
 
 func with_claim(name: String, value) -> JWTBaseBuilder:
-	add_claim(name, str(value))
-	return self
+    add_claim(name, str(value))
+    return self
 
 func with_payload(claims: Dictionary) -> JWTBaseBuilder:
-	for claim in claims.keys():
-		add_claim(claim, claims[claim])
-	return self
+    for claim in claims.keys():
+        add_claim(claim, claims[claim])
+    return self
 
 func add_claim(claim_name: String, claim_value) -> void:
-	return
+    return

--- a/addons/jwt/src/JWTBaseBuilder.gd
+++ b/addons/jwt/src/JWTBaseBuilder.gd
@@ -1,61 +1,61 @@
-extends Reference
+extends RefCounted
 class_name JWTBaseBuilder
 
 func with_header(header_claims: Dictionary) -> JWTBaseBuilder:
-    self.header_claims = header_claims
-    return self
+	self.header_claims = header_claims
+	return self
 
 func with_algorithm(algorithm: String) -> JWTBaseBuilder:
-    self.header_claims[JWTClaims.Public.ALGORITHM] = algorithm
-    return self
+	self.header_claims[JWTClaims.Public.ALGORITHM] = algorithm
+	return self
 
 func with_type(type: String) -> JWTBaseBuilder:
-    self.header_claims[JWTClaims.Public.TYPE] = type
-    return self
+	self.header_claims[JWTClaims.Public.TYPE] = type
+	return self
 
 func with_key_id(key_id: String) -> JWTBaseBuilder:
-    self.header_claims[JWTClaims.Public.KEY_ID] = key_id
-    return self
+	self.header_claims[JWTClaims.Public.KEY_ID] = key_id
+	return self
 
 func with_issuer(issuer: String) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.ISSUER, issuer)
-    return self
+	add_claim(JWTClaims.Public.ISSUER, issuer)
+	return self
 
 func with_subject(subject: String) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.SUBJECT, subject)
-    return self
+	add_claim(JWTClaims.Public.SUBJECT, subject)
+	return self
 
-func with_audience(audience: PoolStringArray) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.AUDIENCE, audience)
-    return self
+func with_audience(audience: PackedStringArray) -> JWTBaseBuilder:
+	add_claim(JWTClaims.Public.AUDIENCE, audience)
+	return self
 
 # Expires At in UNIX time (OS.get_unix_time())
 func with_expires_at(expires_at: int) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.EXPRIES_AT, expires_at)
-    return self
+	add_claim(JWTClaims.Public.EXPRIES_AT, expires_at)
+	return self
 
 # Not Before in UNIX time (OS.get_unix_time())
 func with_not_before(not_before: int) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.NOT_BEFORE, not_before)
-    return self
+	add_claim(JWTClaims.Public.NOT_BEFORE, not_before)
+	return self
 
 # Issued At in UNIX time (OS.get_unix_time())
 func with_issued_at(issued_at: int) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.ISSUED_AT, issued_at)
-    return self
+	add_claim(JWTClaims.Public.ISSUED_AT, issued_at)
+	return self
 
 func with_jwt_id(jwt_id: String) -> JWTBaseBuilder:
-    self.header_claims[JWTClaims.Public.JWT_ID] = jwt_id
-    return self
+	self.header_claims[JWTClaims.Public.JWT_ID] = jwt_id
+	return self
 
 func with_claim(name: String, value) -> JWTBaseBuilder:
-    add_claim(name, str(value))
-    return self
+	add_claim(name, str(value))
+	return self
 
 func with_payload(claims: Dictionary) -> JWTBaseBuilder:
-    for claim in claims.keys():
-        add_claim(claim, claims[claim])
-    return self
+	for claim in claims.keys():
+		add_claim(claim, claims[claim])
+	return self
 
 func add_claim(claim_name: String, claim_value) -> void:
-    return
+	return

--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -8,10 +8,12 @@ var header_claims: Dictionary = { alg = "", typ = "JWT" }
 var payload_claims: Dictionary
 var secret: String
 
-func _init(algorithm: JWTAlgorithm = null, header_claims: Dictionary = {}, payload_claims: Dictionary = {}):
-	if algorithm != null: self.algorithm = algorithm
-	if not header_claims.is_empty(): self.header_claims = header_claims
-	if not payload_claims.is_empty(): self.payload_claims = payload_claims
+func _init(algorithm_param: JWTAlgorithm = null, header_claims_param: Dictionary = {}, payload_claims_param: Dictionary = {}):
+	if not header_claims_param.is_empty(): self.header_claims = header_claims_param
+	if not payload_claims_param.is_empty(): self.payload_claims = payload_claims_param
+	if algorithm_param != null:
+		self.algorithm = algorithm_param
+		self.header_claims.alg = self.algorithm.get_name()
 
 func add_claim(name: String, value) -> void:
 	match typeof(value):

--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -9,37 +9,37 @@ var payload_claims: Dictionary
 var secret: String
 
 func _init(algorithm_param: JWTAlgorithm = null, header_claims_param: Dictionary = {}, payload_claims_param: Dictionary = {}):
-	if not header_claims_param.is_empty(): self.header_claims = header_claims_param
-	if not payload_claims_param.is_empty(): self.payload_claims = payload_claims_param
-	if algorithm_param != null:
-		self.algorithm = algorithm_param
-		self.header_claims.alg = self.algorithm.get_name()
+    if not header_claims_param.is_empty(): self.header_claims = header_claims_param
+    if not payload_claims_param.is_empty(): self.payload_claims = payload_claims_param
+    if algorithm_param != null:
+        self.algorithm = algorithm_param
+        self.header_claims.alg = self.algorithm.get_name()
 
 func add_claim(name: String, value) -> void:
-	match typeof(value):
-		TYPE_ARRAY, TYPE_STRING_ARRAY: 
-			if value.size() == 0 : 
-				self.payload_claims.erase(name)
-				return
-		TYPE_STRING: 
-			if value.length() == 0: 
-				self.payload_claims.erase(name)
-				return
-		_:  
-			if value == null:
-				self.payload_claims.erase(name)
-				return
-	self.payload_claims[name] = value
+    match typeof(value):
+        TYPE_ARRAY, TYPE_STRING_ARRAY: 
+            if value.size() == 0 : 
+                self.payload_claims.erase(name)
+                return
+        TYPE_STRING: 
+            if value.length() == 0: 
+                self.payload_claims.erase(name)
+                return
+        _:  
+            if value == null:
+                self.payload_claims.erase(name)
+                return
+    self.payload_claims[name] = value
 
 
 func sign(algorithm: JWTAlgorithm = null) -> String:
-	if algorithm != null: self.algorithm = algorithm
-	assert(algorithm != null, "Can't sign a JWT without an Algorithm")
-	with_algorithm(algorithm.get_name())
-	var header_serializer : JSON = JSON.new()
-	var header: String = JWTUtils.base64URL_encode(header_serializer.stringify(self.header_claims).to_utf8_buffer())
-	var payload_serializer : JSON = JSON.new()
-	var payload: String = JWTUtils.base64URL_encode(payload_serializer.stringify(self.payload_claims).to_utf8_buffer())
-	var signature_bytes: PackedByteArray = algorithm.sign(header+"."+payload)
-	var signature: String = JWTUtils.base64URL_encode(signature_bytes)
-	return "%s.%s.%s" % [header, payload, signature]
+    if algorithm != null: self.algorithm = algorithm
+    assert(algorithm != null, "Can't sign a JWT without an Algorithm")
+    with_algorithm(algorithm.get_name())
+    var header_serializer : JSON = JSON.new()
+    var header: String = JWTUtils.base64URL_encode(header_serializer.stringify(self.header_claims).to_utf8_buffer())
+    var payload_serializer : JSON = JSON.new()
+    var payload: String = JWTUtils.base64URL_encode(payload_serializer.stringify(self.payload_claims).to_utf8_buffer())
+    var signature_bytes: PackedByteArray = algorithm.sign(header+"."+payload)
+    var signature: String = JWTUtils.base64URL_encode(signature_bytes)
+    return "%s.%s.%s" % [header, payload, signature]

--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -9,33 +9,35 @@ var payload_claims: Dictionary
 var secret: String
 
 func _init(algorithm: JWTAlgorithm = null, header_claims: Dictionary = {}, payload_claims: Dictionary = {}):
-    if algorithm != null: self.algorithm = algorithm
-    if not header_claims.empty(): self.header_claims = header_claims
-    if not payload_claims.empty(): self.payload_claims = payload_claims
+	if algorithm != null: self.algorithm = algorithm
+	if not header_claims.is_empty(): self.header_claims = header_claims
+	if not payload_claims.is_empty(): self.payload_claims = payload_claims
 
 func add_claim(name: String, value) -> void:
-    match typeof(value):
-        TYPE_ARRAY, TYPE_STRING_ARRAY: 
-            if value.size() == 0 : 
-                self.payload_claims.erase(name)
-                return
-        TYPE_STRING: 
-            if value.length() == 0: 
-                self.payload_claims.erase(name)
-                return
-        _:  
-            if value == null:
-                self.payload_claims.erase(name)
-                return
-    self.payload_claims[name] = value
+	match typeof(value):
+		TYPE_ARRAY, TYPE_STRING_ARRAY: 
+			if value.size() == 0 : 
+				self.payload_claims.erase(name)
+				return
+		TYPE_STRING: 
+			if value.length() == 0: 
+				self.payload_claims.erase(name)
+				return
+		_:  
+			if value == null:
+				self.payload_claims.erase(name)
+				return
+	self.payload_claims[name] = value
 
 
 func sign(algorithm: JWTAlgorithm = null) -> String:
-    if algorithm != null: self.algorithm = algorithm
-    assert(algorithm != null, "Can't sign a JWT without an Algorithm")
-    with_algorithm(algorithm.get_name())
-    var header: String = JWTUtils.base64URL_encode(JSON.print(self.header_claims).to_utf8())
-    var payload: String = JWTUtils.base64URL_encode(JSON.print(self.payload_claims).to_utf8())
-    var signature_bytes: PoolByteArray = algorithm.sign(header+"."+payload)
-    var signature: String = JWTUtils.base64URL_encode(signature_bytes)
-    return "%s.%s.%s" % [header, payload, signature]
+	if algorithm != null: self.algorithm = algorithm
+	assert(algorithm != null, "Can't sign a JWT without an Algorithm")
+	with_algorithm(algorithm.get_name())
+	var header_serializer : JSON = JSON.new()
+	var header: String = JWTUtils.base64URL_encode(header_serializer.stringify(self.header_claims).to_utf8_buffer())
+	var payload_serializer : JSON = JSON.new()
+	var payload: String = JWTUtils.base64URL_encode(payload_serializer.stringify(self.payload_claims).to_utf8_buffer())
+	var signature_bytes: PackedByteArray = algorithm.sign(header+"."+payload)
+	var signature: String = JWTUtils.base64URL_encode(signature_bytes)
+	return "%s.%s.%s" % [header, payload, signature]

--- a/addons/jwt/src/JWTClaims.gd
+++ b/addons/jwt/src/JWTClaims.gd
@@ -3,17 +3,17 @@ class_name JWTClaims
 
 
 class Public:
-	#   Header
-	const ALGORITHM: String = "alg"
-	const CONTENT_TYPE: String = "cty"
-	const TYPE: String = "typ" 
-	const KEY_ID: String = "kid"
+    #   Header
+    const ALGORITHM: String = "alg"
+    const CONTENT_TYPE: String = "cty"
+    const TYPE: String = "typ" 
+    const KEY_ID: String = "kid"
 
-	#   Payload
-	const ISSUER: String = "iss"
-	const SUBJECT: String = "sub"
-	const EXPRIES_AT: String = "exp"
-	const NOT_BEFORE: String = "nbf"
-	const ISSUED_AT: String = "iat"
-	const JWT_ID: String = "jti"
-	const AUDIENCE: String = "aud"
+    #   Payload
+    const ISSUER: String = "iss"
+    const SUBJECT: String = "sub"
+    const EXPRIES_AT: String = "exp"
+    const NOT_BEFORE: String = "nbf"
+    const ISSUED_AT: String = "iat"
+    const JWT_ID: String = "jti"
+    const AUDIENCE: String = "aud"

--- a/addons/jwt/src/JWTClaims.gd
+++ b/addons/jwt/src/JWTClaims.gd
@@ -1,19 +1,19 @@
-extends Reference
+extends RefCounted
 class_name JWTClaims
 
 
 class Public:
-    #   Header
-    const ALGORITHM: String = "alg"
-    const CONTENT_TYPE: String = "cty"
-    const TYPE: String = "typ" 
-    const KEY_ID: String = "kid"
+	#   Header
+	const ALGORITHM: String = "alg"
+	const CONTENT_TYPE: String = "cty"
+	const TYPE: String = "typ" 
+	const KEY_ID: String = "kid"
 
-    #   Payload
-    const ISSUER: String = "iss"
-    const SUBJECT: String = "sub"
-    const EXPRIES_AT: String = "exp"
-    const NOT_BEFORE: String = "nbf"
-    const ISSUED_AT: String = "iat"
-    const JWT_ID: String = "jti"
-    const AUDIENCE: String = "aud"
+	#   Payload
+	const ISSUER: String = "iss"
+	const SUBJECT: String = "sub"
+	const EXPRIES_AT: String = "exp"
+	const NOT_BEFORE: String = "nbf"
+	const ISSUED_AT: String = "iat"
+	const JWT_ID: String = "jti"
+	const AUDIENCE: String = "aud"

--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -1,4 +1,4 @@
-extends Reference
+extends RefCounted
 class_name JWTDecoder
 
 var parts: Array = []
@@ -6,71 +6,71 @@ var header_claims: Dictionary = {}
 var payload_claims: Dictionary = {}
 
 func _init(jwt: String):
-    self.parts = jwt.split(".")
-    var header: String = JWTUtils.base64URL_decode(self.parts[0])
-    var payload: String = JWTUtils.base64URL_decode(self.parts[1])
-    self.header_claims = _parse_json(header)
-    self.payload_claims = _parse_json(payload)
+	self.parts = jwt.split(".")
+	var header: PackedByteArray = JWTUtils.base64URL_decode(self.parts[0])
+	var payload: PackedByteArray = JWTUtils.base64URL_decode(self.parts[1])
+	self.header_claims = _parse_json(header.get_string_from_utf8())
+	self.payload_claims = _parse_json(payload.get_string_from_utf8())
 
 func _parse_json(field) -> Dictionary:
-    var parse_result: JSONParseResult = JSON.parse(field)
-    if parse_result.error != OK:
-        return {}
-    return parse_result.result
+	var parse_result = JSON.new()
+	if parse_result.parse(field) != OK:
+		return {}
+	return parse_result.get_data()
 
 func get_algorithm() -> String:
-    return self.header_claims.get(JWTClaims.Public.ALGORITHM, "null")
+	return self.header_claims.get(JWTClaims.Public.ALGORITHM, "null")
 
 func get_type() -> String:
-    return self.header_claims.get(JWTClaims.Public.TYPE, "null")
+	return self.header_claims.get(JWTClaims.Public.TYPE, "null")
 
 func get_content_type() -> String:
-    return self.header_claims.get(JWTClaims.Public.CONTENT_TYPE, "null")
+	return self.header_claims.get(JWTClaims.Public.CONTENT_TYPE, "null")
 
 func get_key_id() -> String:
-    return self.header_claims.get(JWTClaims.Public.KEY_ID, "null")
+	return self.header_claims.get(JWTClaims.Public.KEY_ID, "null")
 
 func get_header_claim(name: String):
-    return self.header_claims.get(name, null)
+	return self.header_claims.get(name, null)
 
 func get_header_claims() -> Dictionary:
-    return self.header_claims
+	return self.header_claims
 
 func get_issuer() -> String:
-    return self.payload_claims.get(JWTClaims.Public.ISSUER, "null")
+	return self.payload_claims.get(JWTClaims.Public.ISSUER, "null")
 
 func get_subject() -> String:
-    return self.payload_claims.get(JWTClaims.Public.SUBJECT, "null")
+	return self.payload_claims.get(JWTClaims.Public.SUBJECT, "null")
 
-func get_audience() -> PoolStringArray:
-    return self.payload_claims.get(JWTClaims.Public.AUDIENCE, "null")
+func get_audience() -> PackedByteArray:
+	return self.payload_claims.get(JWTClaims.Public.AUDIENCE, "null")
 
 func get_expires_at() -> int:
-    return self.payload_claims.get(JWTClaims.Public.EXPRIES_AT, -1)
+	return self.payload_claims.get(JWTClaims.Public.EXPRIES_AT, -1)
 
 func get_not_before() -> int:
-    return self.payload_claims.get(JWTClaims.Public.NOT_BEFORE, -1)
+	return self.payload_claims.get(JWTClaims.Public.NOT_BEFORE, -1)
 
 func get_issued_at() -> int:
-    return self.payload_claims.get(JWTClaims.Public.ISSUED_AT, -1)
+	return self.payload_claims.get(JWTClaims.Public.ISSUED_AT, -1)
 
 func get_id() -> String:
-    return self.payload_claims.get(JWTClaims.Public.JWT_ID, "null")
+	return self.payload_claims.get(JWTClaims.Public.JWT_ID, "null")
 
 func get_claim(name: String):
-    return self.payload_claims.get(name, "null")
+	return self.payload_claims.get(name, "null")
 
 func get_claims() -> Dictionary:
-    return self.payload_claims
+	return self.payload_claims
 
 func get_header() -> String:
-    return self.parts[0]
+	return self.parts[0]
 
 func get_payload() -> String:
-    return self.parts[1]
+	return self.parts[1]
 
 func get_signature() -> String:
-    return self.parts[2]
+	return self.parts[2]
 
 func get_token() -> String:
-    return ("%s.%s.%s" % parts)
+	return ("%s.%s.%s" % parts)

--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -6,71 +6,71 @@ var header_claims: Dictionary = {}
 var payload_claims: Dictionary = {}
 
 func _init(jwt: String):
-	self.parts = jwt.split(".")
-	var header: PackedByteArray = JWTUtils.base64URL_decode(self.parts[0])
-	var payload: PackedByteArray = JWTUtils.base64URL_decode(self.parts[1])
-	self.header_claims = _parse_json(header.get_string_from_utf8())
-	self.payload_claims = _parse_json(payload.get_string_from_utf8())
+    self.parts = jwt.split(".")
+    var header: PackedByteArray = JWTUtils.base64URL_decode(self.parts[0])
+    var payload: PackedByteArray = JWTUtils.base64URL_decode(self.parts[1])
+    self.header_claims = _parse_json(header.get_string_from_utf8())
+    self.payload_claims = _parse_json(payload.get_string_from_utf8())
 
 func _parse_json(field) -> Dictionary:
-	var parse_result = JSON.new()
-	if parse_result.parse(field) != OK:
-		return {}
-	return parse_result.get_data()
+    var parse_result = JSON.new()
+    if parse_result.parse(field) != OK:
+        return {}
+    return parse_result.get_data()
 
 func get_algorithm() -> String:
-	return self.header_claims.get(JWTClaims.Public.ALGORITHM, "null")
+    return self.header_claims.get(JWTClaims.Public.ALGORITHM, "null")
 
 func get_type() -> String:
-	return self.header_claims.get(JWTClaims.Public.TYPE, "null")
+    return self.header_claims.get(JWTClaims.Public.TYPE, "null")
 
 func get_content_type() -> String:
-	return self.header_claims.get(JWTClaims.Public.CONTENT_TYPE, "null")
+    return self.header_claims.get(JWTClaims.Public.CONTENT_TYPE, "null")
 
 func get_key_id() -> String:
-	return self.header_claims.get(JWTClaims.Public.KEY_ID, "null")
+    return self.header_claims.get(JWTClaims.Public.KEY_ID, "null")
 
 func get_header_claim(name: String):
-	return self.header_claims.get(name, null)
+    return self.header_claims.get(name, null)
 
 func get_header_claims() -> Dictionary:
-	return self.header_claims
+    return self.header_claims
 
 func get_issuer() -> String:
-	return self.payload_claims.get(JWTClaims.Public.ISSUER, "null")
+    return self.payload_claims.get(JWTClaims.Public.ISSUER, "null")
 
 func get_subject() -> String:
-	return self.payload_claims.get(JWTClaims.Public.SUBJECT, "null")
+    return self.payload_claims.get(JWTClaims.Public.SUBJECT, "null")
 
 func get_audience() -> PackedByteArray:
-	return self.payload_claims.get(JWTClaims.Public.AUDIENCE, "null")
+    return self.payload_claims.get(JWTClaims.Public.AUDIENCE, "null")
 
 func get_expires_at() -> int:
-	return self.payload_claims.get(JWTClaims.Public.EXPRIES_AT, -1)
+    return self.payload_claims.get(JWTClaims.Public.EXPRIES_AT, -1)
 
 func get_not_before() -> int:
-	return self.payload_claims.get(JWTClaims.Public.NOT_BEFORE, -1)
+    return self.payload_claims.get(JWTClaims.Public.NOT_BEFORE, -1)
 
 func get_issued_at() -> int:
-	return self.payload_claims.get(JWTClaims.Public.ISSUED_AT, -1)
+    return self.payload_claims.get(JWTClaims.Public.ISSUED_AT, -1)
 
 func get_id() -> String:
-	return self.payload_claims.get(JWTClaims.Public.JWT_ID, "null")
+    return self.payload_claims.get(JWTClaims.Public.JWT_ID, "null")
 
 func get_claim(name: String):
-	return self.payload_claims.get(name, "null")
+    return self.payload_claims.get(name, "null")
 
 func get_claims() -> Dictionary:
-	return self.payload_claims
+    return self.payload_claims
 
 func get_header() -> String:
-	return self.parts[0]
+    return self.parts[0]
 
 func get_payload() -> String:
-	return self.parts[1]
+    return self.parts[1]
 
 func get_signature() -> String:
-	return self.parts[2]
+    return self.parts[2]
 
 func get_token() -> String:
-	return ("%s.%s.%s" % parts)
+    return ("%s.%s.%s" % parts)

--- a/addons/jwt/src/JWTUtils.gd
+++ b/addons/jwt/src/JWTUtils.gd
@@ -1,11 +1,11 @@
-extends Reference
+extends RefCounted
 class_name JWTUtils
 
-static func base64URL_encode(input: PoolByteArray) -> String:
-    return Marshalls.raw_to_base64(input).replacen("+","-").replacen("/","_").replacen("=","")
+static func base64URL_encode(input: PackedByteArray) -> String:
+	return Marshalls.raw_to_base64(input).replacen("+","-").replacen("/","_").replacen("=","")
 
-static func base64URL_decode(input: String) -> String:
-    match (input.length() % 4):
-        2: input += "=="
-        3: input += "="
-    return Marshalls.base64_to_utf8(input.replacen("_","/").replacen("-","+"))
+static func base64URL_decode(input: String) -> PackedByteArray:
+	match (input.length() % 4):
+		2: input += "=="
+		3: input += "="
+	return Marshalls.base64_to_raw(input.replacen("_","/").replacen("-","+"))

--- a/addons/jwt/src/JWTUtils.gd
+++ b/addons/jwt/src/JWTUtils.gd
@@ -2,10 +2,10 @@ extends RefCounted
 class_name JWTUtils
 
 static func base64URL_encode(input: PackedByteArray) -> String:
-	return Marshalls.raw_to_base64(input).replacen("+","-").replacen("/","_").replacen("=","")
+    return Marshalls.raw_to_base64(input).replacen("+","-").replacen("/","_").replacen("=","")
 
 static func base64URL_decode(input: String) -> PackedByteArray:
-	match (input.length() % 4):
-		2: input += "=="
-		3: input += "="
-	return Marshalls.base64_to_raw(input.replacen("_","/").replacen("-","+"))
+    match (input.length() % 4):
+        2: input += "=="
+        3: input += "="
+    return Marshalls.base64_to_raw(input.replacen("_","/").replacen("-","+"))

--- a/addons/jwt/src/JWTVerifier.gd
+++ b/addons/jwt/src/JWTVerifier.gd
@@ -1,14 +1,14 @@
-extends Reference
+extends RefCounted
 class_name JWTVerifier
 
-enum Exceptions {
-    OK,
-    INVALID_HEADER,
-    INVALID_PAYLOAD,
-    ALGORITHM_MISMATCHING,
-    INVALID_SIGNATURE,
-    TOKEN_EXPIRED,
-    CLAIM_NOT_VALID
+enum JWTExceptions {
+	OK,
+	INVALID_HEADER,
+	INVALID_PAYLOAD,
+	ALGORITHM_MISMATCHING,
+	INVALID_SIGNATURE,
+	TOKEN_EXPIRED,
+	CLAIM_NOT_VALID
    }
 
 var jwt_decoder: JWTDecoder
@@ -18,83 +18,83 @@ var clock: int
 var exception: String
 
 func _init(algorithm: JWTAlgorithm, claims: Dictionary, clock: int):
-    self.algorithm = algorithm
-    self.claims = claims
-    self.clock = clock
+	self.algorithm = algorithm
+	self.claims = claims
+	self.clock = clock
 
 func verify_algorithm(jwt_decoder: JWTDecoder, algorithm: JWTAlgorithm) -> bool:
-    self.exception = "The provided Algorithm doesn't match the one defined in the JWT's Header."
-    return jwt_decoder.get_algorithm() == algorithm.get_name()
+	self.exception = "The provided Algorithm doesn't match the one defined in the JWT's Header."
+	return jwt_decoder.get_algorithm() == algorithm.get_name()
 
 func verify_signature(jwt_decoder: JWTDecoder) -> bool:
-    self.exception = "The provided Algorithm doesn't match the one used to sign the JWT."
-    return algorithm.verify(jwt_decoder)
+	self.exception = "The provided Algorithm doesn't match the one used to sign the JWT."
+	return algorithm.verify(jwt_decoder)
 
 func verify_claim_values(jwt_decoder: JWTDecoder, expected_claims: Dictionary) -> bool:
-    for claim in expected_claims.keys(): 
-        match claim:
-            JWTClaims.Public.EXPRIES_AT:
-                if not assert_valid_date_claim(jwt_decoder.get_expires_at(), expected_claims.get(claim), true):
-                    self.exception = "The Token has expired on %s." % OS.get_datetime_from_unix_time(jwt_decoder.get_expires_at())
-                    return false
-            JWTClaims.Public.ISSUED_AT:
-                if not assert_valid_date_claim(jwt_decoder.get_issued_at(), expected_claims.get(claim), false):
-                    self.exception = "The Token can't be used before %s." % OS.get_datetime_from_unix_time(jwt_decoder.get_expires_at())
-                    return false
-            JWTClaims.Public.NOT_BEFORE:
-                if not assert_valid_date_claim(jwt_decoder.get_not_before(), expected_claims.get(claim), false):
-                    self.exception = "The Token can't be used before %s." % OS.get_datetime_from_unix_time(jwt_decoder.get_expires_at())
-                    return false
-            JWTClaims.Public.ISSUER:
-                if not jwt_decoder.get_issuer() == expected_claims.get(claim):
-                    self.exception = "The Claim 'iss' value doesn't match the required issuer."
-                    return false
-            JWTClaims.Public.JWT_ID:
-                if not jwt_decoder.get_id() == expected_claims.get(claim):
-                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
-                    return false
-            JWTClaims.Public.SUBJECT:
-                if not jwt_decoder.get_subject() == expected_claims.get(claim):
-                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
-                    return false
-            _:
-                if not assert_claim_present(jwt_decoder, claim): 
-                    self.exception = "The Claim '%s' is not present in the JWT." % claim
-                    return false
-                if not assert_claim_value(jwt_decoder, claim): 
-                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
-                    return false
-    return true
+	for claim in expected_claims.keys(): 
+		match claim:
+			JWTClaims.Public.EXPRIES_AT:
+				if not assert_valid_date_claim(jwt_decoder.get_expires_at(), expected_claims.get(claim), true):
+					self.exception = "The Token has expired on %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+					return false
+			JWTClaims.Public.ISSUED_AT:
+				if not assert_valid_date_claim(jwt_decoder.get_issued_at(), expected_claims.get(claim), false):
+					self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+					return false
+			JWTClaims.Public.NOT_BEFORE:
+				if not assert_valid_date_claim(jwt_decoder.get_not_before(), expected_claims.get(claim), false):
+					self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+					return false
+			JWTClaims.Public.ISSUER:
+				if not jwt_decoder.get_issuer() == expected_claims.get(claim):
+					self.exception = "The Claim 'iss' value doesn't match the required issuer."
+					return false
+			JWTClaims.Public.JWT_ID:
+				if not jwt_decoder.get_id() == expected_claims.get(claim):
+					self.exception = "The Claim '%s' value doesn't match the required one." % claim
+					return false
+			JWTClaims.Public.SUBJECT:
+				if not jwt_decoder.get_subject() == expected_claims.get(claim):
+					self.exception = "The Claim '%s' value doesn't match the required one." % claim
+					return false
+			_:
+				if not assert_claim_present(jwt_decoder, claim): 
+					self.exception = "The Claim '%s' is not present in the JWT." % claim
+					return false
+				if not assert_claim_value(jwt_decoder, claim): 
+					self.exception = "The Claim '%s' value doesn't match the required one." % claim
+					return false
+	return true
 
 func assert_claim_present(jew_decoder: JWTDecoder, claim: String) -> bool:
-    return jwt_decoder.get_claims().has(claim)
+	return jwt_decoder.get_claims().has(claim)
 
 func assert_claim_value(jwt_decoder: JWTDecoder, claim: String) -> bool:
-    var valid_value: bool = -1
-    match typeof(jwt_decoder.get_claims().get(claim)):
-        TYPE_STRING: valid_value = (jwt_decoder.get_claims().get(claim) != "" and jwt_decoder.get_claims().get(claim) != "null")
-        TYPE_INT: valid_value = (jwt_decoder.get_claims().get(claim) >= 0)
-    return (jwt_decoder.get_claims().get(claim) != null and valid_value and jwt_decoder.get_claims().get(claim) == self.claims.get(claim))
+	var valid_value: bool = -1
+	match typeof(jwt_decoder.get_claims().get(claim)):
+		TYPE_STRING: valid_value = (jwt_decoder.get_claims().get(claim) != "" and jwt_decoder.get_claims().get(claim) != "null")
+		TYPE_INT: valid_value = (jwt_decoder.get_claims().get(claim) >= 0)
+	return (jwt_decoder.get_claims().get(claim) != null and valid_value and jwt_decoder.get_claims().get(claim) == self.claims.get(claim))
 
 func assert_valid_date_claim(date: int, leeway: int, should_be_future: bool) -> bool:
-    if date == null: return true
-    if should_be_future: return (self.clock - leeway) < date
-    else: return (self.clock + leeway) > date
+	if date == null: return true
+	if should_be_future: return (self.clock - leeway) < date
+	else: return (self.clock + leeway) > date
 
 func assert_valid_header(jwt_decoder: JWTDecoder) -> bool:
-    self.exception = "The header is empty or invalid."
-    return not jwt_decoder.header_claims.empty()    
+	self.exception = "The header is empty or invalid."
+	return not jwt_decoder.header_claims.is_empty()    
 
 func assert_valid_payload(jwt_decoder: JWTDecoder) -> bool:
-    self.exception = "The payload is empty or invalid."
-    return not jwt_decoder.payload_claims.empty()
+	self.exception = "The payload is empty or invalid."
+	return not jwt_decoder.payload_claims.is_empty()
 
-func verify(jwt: String) -> int:
-    self.jwt_decoder = JWTDecoder.new(jwt)
-    if not assert_valid_header(self.jwt_decoder): return Exceptions.INVALID_HEADER
-    if not assert_valid_payload(self.jwt_decoder): return Exceptions.INVALID_PAYLOAD 
-    if not verify_algorithm(self.jwt_decoder, algorithm): return Exceptions.ALGORITHM_MISMATCHING
-    if not verify_signature(self.jwt_decoder): return Exceptions.INVALID_SIGNATURE
-    if not verify_claim_values(self.jwt_decoder, self.claims): return Exceptions.CLAIM_NOT_VALID
-    self.exception = ""
-    return Exceptions.OK
+func verify(jwt: String) -> JWTExceptions:
+	self.jwt_decoder = JWTDecoder.new(jwt)
+	if not assert_valid_header(self.jwt_decoder): return JWTExceptions.INVALID_HEADER
+	if not assert_valid_payload(self.jwt_decoder): return JWTExceptions.INVALID_PAYLOAD 
+	if not verify_algorithm(self.jwt_decoder, algorithm): return JWTExceptions.ALGORITHM_MISMATCHING
+	if not verify_signature(self.jwt_decoder): return JWTExceptions.INVALID_SIGNATURE
+	if not verify_claim_values(self.jwt_decoder, self.claims): return JWTExceptions.CLAIM_NOT_VALID
+	self.exception = ""
+	return JWTExceptions.OK

--- a/addons/jwt/src/JWTVerifier.gd
+++ b/addons/jwt/src/JWTVerifier.gd
@@ -2,13 +2,13 @@ extends RefCounted
 class_name JWTVerifier
 
 enum JWTExceptions {
-	OK,
-	INVALID_HEADER,
-	INVALID_PAYLOAD,
-	ALGORITHM_MISMATCHING,
-	INVALID_SIGNATURE,
-	TOKEN_EXPIRED,
-	CLAIM_NOT_VALID
+    OK,
+    INVALID_HEADER,
+    INVALID_PAYLOAD,
+    ALGORITHM_MISMATCHING,
+    INVALID_SIGNATURE,
+    TOKEN_EXPIRED,
+    CLAIM_NOT_VALID
    }
 
 var jwt_decoder: JWTDecoder
@@ -18,83 +18,83 @@ var clock: int
 var exception: String
 
 func _init(algorithm: JWTAlgorithm, claims: Dictionary, clock: int):
-	self.algorithm = algorithm
-	self.claims = claims
-	self.clock = clock
+    self.algorithm = algorithm
+    self.claims = claims
+    self.clock = clock
 
 func verify_algorithm(jwt_decoder: JWTDecoder, algorithm: JWTAlgorithm) -> bool:
-	self.exception = "The provided Algorithm doesn't match the one defined in the JWT's Header."
-	return jwt_decoder.get_algorithm() == algorithm.get_name()
+    self.exception = "The provided Algorithm doesn't match the one defined in the JWT's Header."
+    return jwt_decoder.get_algorithm() == algorithm.get_name()
 
 func verify_signature(jwt_decoder: JWTDecoder) -> bool:
-	self.exception = "The provided Algorithm doesn't match the one used to sign the JWT."
-	return algorithm.verify(jwt_decoder)
+    self.exception = "The provided Algorithm doesn't match the one used to sign the JWT."
+    return algorithm.verify(jwt_decoder)
 
 func verify_claim_values(jwt_decoder: JWTDecoder, expected_claims: Dictionary) -> bool:
-	for claim in expected_claims.keys(): 
-		match claim:
-			JWTClaims.Public.EXPRIES_AT:
-				if not assert_valid_date_claim(jwt_decoder.get_expires_at(), expected_claims.get(claim), true):
-					self.exception = "The Token has expired on %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
-					return false
-			JWTClaims.Public.ISSUED_AT:
-				if not assert_valid_date_claim(jwt_decoder.get_issued_at(), expected_claims.get(claim), false):
-					self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
-					return false
-			JWTClaims.Public.NOT_BEFORE:
-				if not assert_valid_date_claim(jwt_decoder.get_not_before(), expected_claims.get(claim), false):
-					self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
-					return false
-			JWTClaims.Public.ISSUER:
-				if not jwt_decoder.get_issuer() == expected_claims.get(claim):
-					self.exception = "The Claim 'iss' value doesn't match the required issuer."
-					return false
-			JWTClaims.Public.JWT_ID:
-				if not jwt_decoder.get_id() == expected_claims.get(claim):
-					self.exception = "The Claim '%s' value doesn't match the required one." % claim
-					return false
-			JWTClaims.Public.SUBJECT:
-				if not jwt_decoder.get_subject() == expected_claims.get(claim):
-					self.exception = "The Claim '%s' value doesn't match the required one." % claim
-					return false
-			_:
-				if not assert_claim_present(jwt_decoder, claim): 
-					self.exception = "The Claim '%s' is not present in the JWT." % claim
-					return false
-				if not assert_claim_value(jwt_decoder, claim): 
-					self.exception = "The Claim '%s' value doesn't match the required one." % claim
-					return false
-	return true
+    for claim in expected_claims.keys(): 
+        match claim:
+            JWTClaims.Public.EXPRIES_AT:
+                if not assert_valid_date_claim(jwt_decoder.get_expires_at(), expected_claims.get(claim), true):
+                    self.exception = "The Token has expired on %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+                    return false
+            JWTClaims.Public.ISSUED_AT:
+                if not assert_valid_date_claim(jwt_decoder.get_issued_at(), expected_claims.get(claim), false):
+                    self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+                    return false
+            JWTClaims.Public.NOT_BEFORE:
+                if not assert_valid_date_claim(jwt_decoder.get_not_before(), expected_claims.get(claim), false):
+                    self.exception = "The Token can't be used before %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
+                    return false
+            JWTClaims.Public.ISSUER:
+                if not jwt_decoder.get_issuer() == expected_claims.get(claim):
+                    self.exception = "The Claim 'iss' value doesn't match the required issuer."
+                    return false
+            JWTClaims.Public.JWT_ID:
+                if not jwt_decoder.get_id() == expected_claims.get(claim):
+                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
+                    return false
+            JWTClaims.Public.SUBJECT:
+                if not jwt_decoder.get_subject() == expected_claims.get(claim):
+                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
+                    return false
+            _:
+                if not assert_claim_present(jwt_decoder, claim): 
+                    self.exception = "The Claim '%s' is not present in the JWT." % claim
+                    return false
+                if not assert_claim_value(jwt_decoder, claim): 
+                    self.exception = "The Claim '%s' value doesn't match the required one." % claim
+                    return false
+    return true
 
 func assert_claim_present(jew_decoder: JWTDecoder, claim: String) -> bool:
-	return jwt_decoder.get_claims().has(claim)
+    return jwt_decoder.get_claims().has(claim)
 
 func assert_claim_value(jwt_decoder: JWTDecoder, claim: String) -> bool:
-	var valid_value: bool = -1
-	match typeof(jwt_decoder.get_claims().get(claim)):
-		TYPE_STRING: valid_value = (jwt_decoder.get_claims().get(claim) != "" and jwt_decoder.get_claims().get(claim) != "null")
-		TYPE_INT: valid_value = (jwt_decoder.get_claims().get(claim) >= 0)
-	return (jwt_decoder.get_claims().get(claim) != null and valid_value and jwt_decoder.get_claims().get(claim) == self.claims.get(claim))
+    var valid_value: bool = -1
+    match typeof(jwt_decoder.get_claims().get(claim)):
+        TYPE_STRING: valid_value = (jwt_decoder.get_claims().get(claim) != "" and jwt_decoder.get_claims().get(claim) != "null")
+        TYPE_INT: valid_value = (jwt_decoder.get_claims().get(claim) >= 0)
+    return (jwt_decoder.get_claims().get(claim) != null and valid_value and jwt_decoder.get_claims().get(claim) == self.claims.get(claim))
 
 func assert_valid_date_claim(date: int, leeway: int, should_be_future: bool) -> bool:
-	if date == null: return true
-	if should_be_future: return (self.clock - leeway) < date
-	else: return (self.clock + leeway) > date
+    if date == null: return true
+    if should_be_future: return (self.clock - leeway) < date
+    else: return (self.clock + leeway) > date
 
 func assert_valid_header(jwt_decoder: JWTDecoder) -> bool:
-	self.exception = "The header is empty or invalid."
-	return not jwt_decoder.header_claims.is_empty()    
+    self.exception = "The header is empty or invalid."
+    return not jwt_decoder.header_claims.is_empty()    
 
 func assert_valid_payload(jwt_decoder: JWTDecoder) -> bool:
-	self.exception = "The payload is empty or invalid."
-	return not jwt_decoder.payload_claims.is_empty()
+    self.exception = "The payload is empty or invalid."
+    return not jwt_decoder.payload_claims.is_empty()
 
 func verify(jwt: String) -> JWTExceptions:
-	self.jwt_decoder = JWTDecoder.new(jwt)
-	if not assert_valid_header(self.jwt_decoder): return JWTExceptions.INVALID_HEADER
-	if not assert_valid_payload(self.jwt_decoder): return JWTExceptions.INVALID_PAYLOAD 
-	if not verify_algorithm(self.jwt_decoder, algorithm): return JWTExceptions.ALGORITHM_MISMATCHING
-	if not verify_signature(self.jwt_decoder): return JWTExceptions.INVALID_SIGNATURE
-	if not verify_claim_values(self.jwt_decoder, self.claims): return JWTExceptions.CLAIM_NOT_VALID
-	self.exception = ""
-	return JWTExceptions.OK
+    self.jwt_decoder = JWTDecoder.new(jwt)
+    if not assert_valid_header(self.jwt_decoder): return JWTExceptions.INVALID_HEADER
+    if not assert_valid_payload(self.jwt_decoder): return JWTExceptions.INVALID_PAYLOAD 
+    if not verify_algorithm(self.jwt_decoder, algorithm): return JWTExceptions.ALGORITHM_MISMATCHING
+    if not verify_signature(self.jwt_decoder): return JWTExceptions.INVALID_SIGNATURE
+    if not verify_claim_values(self.jwt_decoder, self.claims): return JWTExceptions.CLAIM_NOT_VALID
+    self.exception = ""
+    return JWTExceptions.OK

--- a/addons/jwt/src/JWTVerifierBuilder.gd
+++ b/addons/jwt/src/JWTVerifierBuilder.gd
@@ -4,69 +4,69 @@ class_name JWTVerifierBuilder
 var algorithm: JWTAlgorithm
 var claims: Dictionary = {}
 var leeway: int = 0
-var ignore_issued_at: bool = false
+var _ignore_issued_at: bool = false
 
 func _init(algorithm: JWTAlgorithm):
-    self.algorithm = algorithm
+	self.algorithm = algorithm
 
 func add_claim(name: String, value) -> void:
-    match typeof(value):
-        TYPE_ARRAY, TYPE_STRING_ARRAY: 
-            if value.size() == 0 : 
-                self.claims.erase(name)
-                return
-        TYPE_STRING: 
-            if value.length() == 0: 
-                self.claims.erase(name)
-                return
-        _:  
-            if value == null:
-                self.claims.erase(name)
-                return
-    self.claims[name] = value
+	match typeof(value):
+		TYPE_ARRAY, TYPE_STRING_ARRAY: 
+			if value.size() == 0 : 
+				self.claims.erase(name)
+				return
+		TYPE_STRING: 
+			if value.length() == 0: 
+				self.claims.erase(name)
+				return
+		_:  
+			if value == null:
+				self.claims.erase(name)
+				return
+	self.claims[name] = value
 
-func with_any_of_issuers(issuers: PoolStringArray) -> JWTVerifierBuilder:
-    add_claim(JWTClaims.Public.ISSUER, issuers)
-    return self
+func with_any_of_issuers(issuers: PackedStringArray) -> JWTVerifierBuilder:
+	add_claim(JWTClaims.Public.ISSUER, issuers)
+	return self
 
-func with_any_of_audience(audience: PoolStringArray) -> JWTVerifierBuilder:
-    add_claim(JWTClaims.Public.AUDIENCE, audience)
-    return self
+func with_any_of_audience(audience: PackedStringArray) -> JWTVerifierBuilder:
+	add_claim(JWTClaims.Public.AUDIENCE, audience)
+	return self
 
 func accept_leeway(leeway: int) -> JWTVerifierBuilder:
-    self.leeway = leeway
-    return self
+	self.leeway = leeway
+	return self
 
 func accept_expire_at(leeway: int) -> JWTVerifierBuilder:
-    with_expires_at(leeway)
-    return self
+	with_expires_at(leeway)
+	return self
 
 func accept_not_before(leeway: int) -> JWTVerifierBuilder:
-    with_not_before(leeway)
-    return self
+	with_not_before(leeway)
+	return self
 
 func accept_issued_at(leeway: int) -> JWTVerifierBuilder:
-    with_issued_at(leeway)
-    return self
+	with_issued_at(leeway)
+	return self
 
-func ignore_issued_at() -> JWTVerifierBuilder:
-    self.ignore_issued_at = true
-    return self
+func ignore_issued_at(v: bool = true) -> JWTVerifierBuilder:
+	self._ignore_issued_at = true
+	return self
 
 func with_claim_presence(claim_name: String) -> JWTVerifierBuilder:
-    add_claim(claim_name, null)
-    return self
+	add_claim(claim_name, null)
+	return self
 
 func _add_leeway() -> void:
-    if (not claims.has(JWTClaims.Public.EXPRIES_AT)):
-        claims[JWTClaims.Public.EXPRIES_AT] = self.leeway
-    if (not claims.has(JWTClaims.Public.NOT_BEFORE)):
-        claims[JWTClaims.Public.NOT_BEFORE] = self.leeway
-    if (not claims.has(JWTClaims.Public.ISSUED_AT)):
-        claims[JWTClaims.Public.ISSUED_AT] = self.leeway
-    if (ignore_issued_at):
-        claims.erase(JWTClaims.Public.ISSUED_AT)
-    
-func build(clock: int = OS.get_unix_time()) -> JWTVerifier:
-    _add_leeway()
-    return JWTVerifier.new(self.algorithm, self.claims, clock)
+	if (not claims.has(JWTClaims.Public.EXPRIES_AT)):
+		claims[JWTClaims.Public.EXPRIES_AT] = self.leeway
+	if (not claims.has(JWTClaims.Public.NOT_BEFORE)):
+		claims[JWTClaims.Public.NOT_BEFORE] = self.leeway
+	if (not claims.has(JWTClaims.Public.ISSUED_AT)):
+		claims[JWTClaims.Public.ISSUED_AT] = self.leeway
+	if (_ignore_issued_at):
+		claims.erase(JWTClaims.Public.ISSUED_AT)
+	
+func build(clock: int = int(Time.get_unix_time_from_system())) -> JWTVerifier:
+	_add_leeway()
+	return JWTVerifier.new(self.algorithm, self.claims, clock)

--- a/addons/jwt/src/JWTVerifierBuilder.gd
+++ b/addons/jwt/src/JWTVerifierBuilder.gd
@@ -7,66 +7,66 @@ var leeway: int = 0
 var _ignore_issued_at: bool = false
 
 func _init(algorithm: JWTAlgorithm):
-	self.algorithm = algorithm
+    self.algorithm = algorithm
 
 func add_claim(name: String, value) -> void:
-	match typeof(value):
-		TYPE_ARRAY, TYPE_STRING_ARRAY: 
-			if value.size() == 0 : 
-				self.claims.erase(name)
-				return
-		TYPE_STRING: 
-			if value.length() == 0: 
-				self.claims.erase(name)
-				return
-		_:  
-			if value == null:
-				self.claims.erase(name)
-				return
-	self.claims[name] = value
+    match typeof(value):
+        TYPE_ARRAY, TYPE_STRING_ARRAY: 
+            if value.size() == 0 : 
+                self.claims.erase(name)
+                return
+        TYPE_STRING: 
+            if value.length() == 0: 
+                self.claims.erase(name)
+                return
+        _:  
+            if value == null:
+                self.claims.erase(name)
+                return
+    self.claims[name] = value
 
 func with_any_of_issuers(issuers: PackedStringArray) -> JWTVerifierBuilder:
-	add_claim(JWTClaims.Public.ISSUER, issuers)
-	return self
+    add_claim(JWTClaims.Public.ISSUER, issuers)
+    return self
 
 func with_any_of_audience(audience: PackedStringArray) -> JWTVerifierBuilder:
-	add_claim(JWTClaims.Public.AUDIENCE, audience)
-	return self
+    add_claim(JWTClaims.Public.AUDIENCE, audience)
+    return self
 
 func accept_leeway(leeway: int) -> JWTVerifierBuilder:
-	self.leeway = leeway
-	return self
+    self.leeway = leeway
+    return self
 
 func accept_expire_at(leeway: int) -> JWTVerifierBuilder:
-	with_expires_at(leeway)
-	return self
+    with_expires_at(leeway)
+    return self
 
 func accept_not_before(leeway: int) -> JWTVerifierBuilder:
-	with_not_before(leeway)
-	return self
+    with_not_before(leeway)
+    return self
 
 func accept_issued_at(leeway: int) -> JWTVerifierBuilder:
-	with_issued_at(leeway)
-	return self
+    with_issued_at(leeway)
+    return self
 
 func ignore_issued_at(v: bool = true) -> JWTVerifierBuilder:
-	self._ignore_issued_at = true
-	return self
+    self._ignore_issued_at = true
+    return self
 
 func with_claim_presence(claim_name: String) -> JWTVerifierBuilder:
-	add_claim(claim_name, null)
-	return self
+    add_claim(claim_name, null)
+    return self
 
 func _add_leeway() -> void:
-	if (not claims.has(JWTClaims.Public.EXPRIES_AT)):
-		claims[JWTClaims.Public.EXPRIES_AT] = self.leeway
-	if (not claims.has(JWTClaims.Public.NOT_BEFORE)):
-		claims[JWTClaims.Public.NOT_BEFORE] = self.leeway
-	if (not claims.has(JWTClaims.Public.ISSUED_AT)):
-		claims[JWTClaims.Public.ISSUED_AT] = self.leeway
-	if (_ignore_issued_at):
-		claims.erase(JWTClaims.Public.ISSUED_AT)
-	
+    if (not claims.has(JWTClaims.Public.EXPRIES_AT)):
+        claims[JWTClaims.Public.EXPRIES_AT] = self.leeway
+    if (not claims.has(JWTClaims.Public.NOT_BEFORE)):
+        claims[JWTClaims.Public.NOT_BEFORE] = self.leeway
+    if (not claims.has(JWTClaims.Public.ISSUED_AT)):
+        claims[JWTClaims.Public.ISSUED_AT] = self.leeway
+    if (_ignore_issued_at):
+        claims.erase(JWTClaims.Public.ISSUED_AT)
+    
 func build(clock: int = int(Time.get_unix_time_from_system())) -> JWTVerifier:
-	_add_leeway()
-	return JWTVerifier.new(self.algorithm, self.claims, clock)
+    _add_leeway()
+    return JWTVerifier.new(self.algorithm, self.claims, clock)


### PR DESCRIPTION
- Replaced Godot 3.x support for Godot 4 support. Suggest pulling into a godot4 branch.
- Repaired RS256 support. It was originally using encrypt() instead of sign(). Verified output with https://jwt.io/
- Added alias RS256 for RSA256 and HS256 for HSA256 so that the documentation is correct without breaking existing API assumptions.
- Renamed header algorithms to match JWT standard.
- Other small fixes (e.g. respecting passed parameters, minor style changes, renamed Exceptions enum to JWTExceptions)
- Created a demo @ [https://github.com/crazychenz/godot-engine.jwt-demo](https://github.com/crazychenz/godot-engine.jwt-demo)
