### PR TITLE
Update for new TYPE enum in Godot4-Beta2

### DIFF
--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -17,7 +17,7 @@ func _init(algorithm_param: JWTAlgorithm = null, header_claims_param: Dictionary
 
 func add_claim(name: String, value) -> void:
     match typeof(value):
-        TYPE_ARRAY, TYPE_STRING_ARRAY: 
+        TYPE_ARRAY, TYPE_PACKED_STRING_ARRAY: 
             if value.size() == 0 : 
                 self.payload_claims.erase(name)
                 return

--- a/addons/jwt/src/JWTVerifierBuilder.gd
+++ b/addons/jwt/src/JWTVerifierBuilder.gd
@@ -11,7 +11,7 @@ func _init(algorithm: JWTAlgorithm):
 
 func add_claim(name: String, value) -> void:
     match typeof(value):
-        TYPE_ARRAY, TYPE_STRING_ARRAY: 
+        TYPE_ARRAY, TYPE_PACKED_STRING_ARRAY: 
             if value.size() == 0 : 
                 self.claims.erase(name)
                 return


### PR DESCRIPTION
## Compilation compatibility with Godot 4 Beta 2

Bug fix, feature, docs update, ...

Current Behaviour: The current code does not compile for Godot 4 Beta 2

Please link any relevant issues here.

PR Behaviour:
The code now compiles

The updated types from here: 
https://docs.godotengine.org/en/latest/classes/class_@globalscope.html?highlight=type_array#enumerations

I hope this is helpful
