### PR TITLE
fix: typo in claim constant

### DIFF
--- a/addons/jwt/src/JWTBaseBuilder.gd
+++ b/addons/jwt/src/JWTBaseBuilder.gd
@@ -31,7 +31,7 @@ func with_audience(audience: PackedStringArray) -> JWTBaseBuilder:
 
 # Expires At in UNIX time (OS.get_unix_time())
 func with_expires_at(expires_at: int) -> JWTBaseBuilder:
-    add_claim(JWTClaims.Public.EXPRIES_AT, expires_at)
+    add_claim(JWTClaims.Public.EXPIRES_AT, expires_at)
     return self
 
 # Not Before in UNIX time (OS.get_unix_time())

--- a/addons/jwt/src/JWTClaims.gd
+++ b/addons/jwt/src/JWTClaims.gd
@@ -12,7 +12,7 @@ class Public:
     #   Payload
     const ISSUER: String = "iss"
     const SUBJECT: String = "sub"
-    const EXPRIES_AT: String = "exp"
+    const EXPIRES_AT: String = "exp"
     const NOT_BEFORE: String = "nbf"
     const ISSUED_AT: String = "iat"
     const JWT_ID: String = "jti"

--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -46,7 +46,7 @@ func get_audience() -> PackedByteArray:
     return self.payload_claims.get(JWTClaims.Public.AUDIENCE, "null")
 
 func get_expires_at() -> int:
-    return self.payload_claims.get(JWTClaims.Public.EXPRIES_AT, -1)
+    return self.payload_claims.get(JWTClaims.Public.EXPIRES_AT, -1)
 
 func get_not_before() -> int:
     return self.payload_claims.get(JWTClaims.Public.NOT_BEFORE, -1)

--- a/addons/jwt/src/JWTVerifier.gd
+++ b/addons/jwt/src/JWTVerifier.gd
@@ -33,7 +33,7 @@ func verify_signature(jwt_decoder: JWTDecoder) -> bool:
 func verify_claim_values(jwt_decoder: JWTDecoder, expected_claims: Dictionary) -> bool:
     for claim in expected_claims.keys(): 
         match claim:
-            JWTClaims.Public.EXPRIES_AT:
+            JWTClaims.Public.EXPIRES_AT:
                 if not assert_valid_date_claim(jwt_decoder.get_expires_at(), expected_claims.get(claim), true):
                     self.exception = "The Token has expired on %s." % Time.get_datetime_string_from_unix_time(jwt_decoder.get_expires_at())
                     return false

--- a/addons/jwt/src/JWTVerifierBuilder.gd
+++ b/addons/jwt/src/JWTVerifierBuilder.gd
@@ -58,8 +58,8 @@ func with_claim_presence(claim_name: String) -> JWTVerifierBuilder:
     return self
 
 func _add_leeway() -> void:
-    if (not claims.has(JWTClaims.Public.EXPRIES_AT)):
-        claims[JWTClaims.Public.EXPRIES_AT] = self.leeway
+    if (not claims.has(JWTClaims.Public.EXPIRES_AT)):
+        claims[JWTClaims.Public.EXPIRES_AT] = self.leeway
     if (not claims.has(JWTClaims.Public.NOT_BEFORE)):
         claims[JWTClaims.Public.NOT_BEFORE] = self.leeway
     if (not claims.has(JWTClaims.Public.ISSUED_AT)):


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR renames `JWTClaims.Public.EXPRIES_AT` to `JWTClaims.Public.EXPIRES_AT`