### PR TITLE
fix: pack aud claim

### DIFF
--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -16,7 +16,15 @@ func _parse_json(field) -> Dictionary:
     var parse_result = JSON.new()
     if parse_result.parse(field) != OK:
         return {}
-    return parse_result.get_data()
+    var data = parse_result.get_data()
+    _maybe_pack_array(data, JWTClaims.Public.AUDIENCE)
+    return data
+ 
+ func _maybe_pack_array(dict, key):
+    if !dict.has(key):
+        return
+    if typeof(dict[key]) == TYPE_ARRAY:
+        dict[key] = PackedStringArray(dict[key])
 
 func get_algorithm() -> String:
     return self.header_claims.get(JWTClaims.Public.ALGORITHM, "null")


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR modifies the JSON parsing functionality of `JWTDecoder` convert the value of `JWTClaims.Public.AUDIENCE` (if present and if it is of `TYPE_ARRAY`) to `TYPE_PACKED_STRING_ARRAY`.

## What is the current behavior?

Fixes #21
