### PR TITLE
fix: remove extra leading space

### DIFF
--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -20,7 +20,7 @@ func _parse_json(field) -> Dictionary:
     _maybe_pack_array(data, JWTClaims.Public.AUDIENCE)
     return data
  
- func _maybe_pack_array(dict, key):
+func _maybe_pack_array(dict, key):
     if !dict.has(key):
         return
     if typeof(dict[key]) == TYPE_ARRAY:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a parse issue introduced by PR #22, which included an extra space before a function definition.
