### PR TITLE
chore: fix unused function parameters

### DIFF
--- a/addons/jwt/src/JWTBaseBuilder.gd
+++ b/addons/jwt/src/JWTBaseBuilder.gd
@@ -57,5 +57,5 @@ func with_payload(claims: Dictionary) -> JWTBaseBuilder:
         add_claim(claim, claims[claim])
     return self
 
-func add_claim(claim_name: String, claim_value) -> void:
+func add_claim(_claim_name: String, _claim_value) -> void:
     return

--- a/addons/jwt/src/JWTVerifierBuilder.gd
+++ b/addons/jwt/src/JWTVerifierBuilder.gd
@@ -50,7 +50,7 @@ func accept_issued_at(leeway: int) -> JWTVerifierBuilder:
     return self
 
 func ignore_issued_at(v: bool = true) -> JWTVerifierBuilder:
-    self._ignore_issued_at = true
+    self._ignore_issued_at = v
     return self
 
 func with_claim_presence(claim_name: String) -> JWTVerifierBuilder:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR renames the parameters to the abstract `JWTBaseBuilder::add_claim()` function with underscore prefixes to indicate that it is intentional that they are not used.

It also uses the `v` parameter to `JWTVerifierBuilder::ignore_issued_at()` instead of ignoring the parameter and always assuming `true`, e.g., calling `ignore_issued_at(false)` is now possible.
