### PR TITLE
chore: remove unused JWTBuilder.secret

### DIFF
--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -6,7 +6,6 @@ var crypto: Crypto = Crypto.new()
 var _algorithm: JWTAlgorithm
 var header_claims: Dictionary = {alg = "", typ = "JWT"}
 var payload_claims: Dictionary
-var secret: String
 
 
 func _init(


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `JWTBuilder.gd` script had a `secret` member variable that was unused. This PR removes that member.