### PR TITLE
chore: use accessors for decoder parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ else:
 var jwt: String = "<a jwt>"
 var jwt_decoder: JWTDecoder = JWT.decode(jwt)
 # Get the JWT as an Array
-print("%s.%s.%s" % jwt_decoder.parts)
+print("%s.%s.%s" % [jwt_decoder.get_header(), jwt_decoder.get_payload(), jwt.decoder.get_signature()])
 # Decode a specific part
 print(JWTUtils.base64URL_decode(jwt_decoder.get_payload()))
 ```

--- a/addons/jwt/src/JWTAlgorithm.gd
+++ b/addons/jwt/src/JWTAlgorithm.gd
@@ -34,9 +34,9 @@ class HSA1:
 		return crypto.hmac_digest(HashingContext.HASH_SHA1, self._secret, text.to_utf8_buffer())
 
 	func verify(jwt: JWTDecoder) -> bool:
-		var payload: String = jwt.parts[0] + "." + jwt.parts[1]
+		var payload: String = jwt.get_header() + "." + jwt.get_payload()
 		var signature_bytes := self.sign(payload)
-		return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)
+		return jwt.get_signature() == JWTUtils.base64URL_encode(signature_bytes)
 
 
 class HS256:
@@ -54,9 +54,9 @@ class HS256:
 		return crypto.hmac_digest(HashingContext.HASH_SHA256, self._secret, text.to_utf8_buffer())
 
 	func verify(jwt: JWTDecoder) -> bool:
-		var payload: String = jwt.parts[0] + "." + jwt.parts[1]
+		var payload: String = jwt.get_header() + "." + jwt.get_payload()
 		var signature_bytes := self.sign(payload)
-		return jwt.parts[2] == JWTUtils.base64URL_encode(signature_bytes)
+		return jwt.get_signature() == JWTUtils.base64URL_encode(signature_bytes)
 
 
 class RS256:
@@ -78,6 +78,6 @@ class RS256:
 
 	func verify(jwt: JWTDecoder) -> bool:
 		var crypto := Crypto.new()
-		var payload: PackedByteArray = (jwt.parts[0] + "." + jwt.parts[1]).sha256_buffer()
-		var signature: PackedByteArray = JWTUtils.base64URL_decode(jwt.parts[2])
+		var payload: PackedByteArray = (jwt.get_header() + "." + jwt.get_payload()).sha256_buffer()
+		var signature: PackedByteArray = JWTUtils.base64URL_decode(jwt.get_signature())
 		return crypto.verify(HashingContext.HASH_SHA256, payload, signature, self._public_key)

--- a/addons/jwt/src/JWTVerifier.gd
+++ b/addons/jwt/src/JWTVerifier.gd
@@ -118,12 +118,12 @@ func assert_valid_date_claim(date: int, leeway: int, should_be_future: bool) -> 
 
 func assert_valid_header(jwt_decoder: JWTDecoder) -> bool:
 	self.exception = "The header is empty or invalid."
-	return not jwt_decoder.header_claims.is_empty()
+	return not jwt_decoder.get_header_claims().is_empty()
 
 
 func assert_valid_payload(jwt_decoder: JWTDecoder) -> bool:
 	self.exception = "The payload is empty or invalid."
-	return not jwt_decoder.payload_claims.is_empty()
+	return not jwt_decoder.get_claims().is_empty()
 
 
 func verify(jwt: String) -> JWTExceptions:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR makes use of existing accessors for JWT members in `JWTDecoder` instances

## What is the current behavior?

Algorithm code directly accesses the `JWTDecoder` member variables `parts`, `header_claims`, and `payload_claims`, even though accessors exist.

## What is the new behavior?

Code using `JWTDecoder` now uses the `get_header()`, `get_payload()`, `get_signature()`, `get_header_claims()`, and `get_claims()` accessors.
