### PR TITLE
style: rename functions to snake case

### DIFF
--- a/addons/jwt/src/JWTAlgorithm.gd
+++ b/addons/jwt/src/JWTAlgorithm.gd
@@ -36,7 +36,7 @@ class HSA1:
 	func verify(jwt: JWTDecoder) -> bool:
 		var payload: String = jwt.get_header() + "." + jwt.get_payload()
 		var signature_bytes := self.sign(payload)
-		return jwt.get_signature() == JWTUtils.base64URL_encode(signature_bytes)
+		return jwt.get_signature() == JWTUtils.urlsafe_b64encode(signature_bytes)
 
 
 class HS256:
@@ -56,7 +56,7 @@ class HS256:
 	func verify(jwt: JWTDecoder) -> bool:
 		var payload: String = jwt.get_header() + "." + jwt.get_payload()
 		var signature_bytes := self.sign(payload)
-		return jwt.get_signature() == JWTUtils.base64URL_encode(signature_bytes)
+		return jwt.get_signature() == JWTUtils.urlsafe_b64encode(signature_bytes)
 
 
 class RS256:
@@ -79,5 +79,5 @@ class RS256:
 	func verify(jwt: JWTDecoder) -> bool:
 		var crypto := Crypto.new()
 		var payload: PackedByteArray = (jwt.get_header() + "." + jwt.get_payload()).sha256_buffer()
-		var signature: PackedByteArray = JWTUtils.base64URL_decode(jwt.get_signature())
+		var signature: PackedByteArray = JWTUtils.urlsafe_b64decode(jwt.get_signature())
 		return crypto.verify(HashingContext.HASH_SHA256, payload, signature, self._public_key)

--- a/addons/jwt/src/JWTBuilder.gd
+++ b/addons/jwt/src/JWTBuilder.gd
@@ -44,12 +44,12 @@ func sign(algorithm: JWTAlgorithm = null) -> String:
 		self._algorithm = algorithm
 	assert(algorithm != null, "Can't sign a JWT without an Algorithm")
 	with_algorithm(algorithm.get_name())
-	var header: String = JWTUtils.base64URL_encode(
+	var header: String = JWTUtils.urlsafe_b64encode(
 		JSON.stringify(self.header_claims).to_utf8_buffer()
 	)
-	var payload: String = JWTUtils.base64URL_encode(
+	var payload: String = JWTUtils.urlsafe_b64encode(
 		JSON.stringify(self.payload_claims).to_utf8_buffer()
 	)
 	var signature_bytes: PackedByteArray = algorithm.sign(header + "." + payload)
-	var signature: String = JWTUtils.base64URL_encode(signature_bytes)
+	var signature: String = JWTUtils.urlsafe_b64encode(signature_bytes)
 	return "%s.%s.%s" % [header, payload, signature]

--- a/addons/jwt/src/JWTDecoder.gd
+++ b/addons/jwt/src/JWTDecoder.gd
@@ -8,8 +8,8 @@ var payload_claims: Dictionary = {}
 
 func _init(jwt: String):
 	self.parts = jwt.split(".")
-	var header: PackedByteArray = JWTUtils.base64URL_decode(self.parts[0])
-	var payload: PackedByteArray = JWTUtils.base64URL_decode(self.parts[1])
+	var header: PackedByteArray = JWTUtils.urlsafe_b64decode(self.parts[0])
+	var payload: PackedByteArray = JWTUtils.urlsafe_b64decode(self.parts[1])
 	self.header_claims = _parse_json(header.get_string_from_utf8())
 	self.payload_claims = _parse_json(payload.get_string_from_utf8())
 

--- a/addons/jwt/src/JWTUtils.gd
+++ b/addons/jwt/src/JWTUtils.gd
@@ -2,11 +2,11 @@ class_name JWTUtils
 extends RefCounted
 
 
-static func base64URL_encode(input: PackedByteArray) -> String:
+static func urlsafe_b64encode(input: PackedByteArray) -> String:
 	return Marshalls.raw_to_base64(input).replacen("+", "-").replacen("/", "_").replacen("=", "")
 
 
-static func base64URL_decode(input: String) -> PackedByteArray:
+static func urlsafe_b64decode(input: String) -> PackedByteArray:
 	match input.length() % 4:
 		2:
 			input += "=="


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR renames the URL-safe base64 functions to be in snake case as required by `gdformat` and the [GDScript Style Guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#functions-and-variables).

NOTE: this is a BC break